### PR TITLE
Improved output for user

### DIFF
--- a/my_rsync.sh
+++ b/my_rsync.sh
@@ -22,19 +22,35 @@ theStartTime=`date +%T`
 scriptLog="rsyncScript-${theDate}-${theStartTime}.log"
 log="rsync-${theDate}-${theStartTime}.log"
 logPath="/Users/bob.zavala/rsyncLogs/"
-echo "rsync Script start time:${theStartTime}" > ${logPath}$scriptLog
-echo "* " >> ${logPath}$scriptLog
-echo "Hello ${USER}! Welcome to the hidden my_rsync script!" >> ${logPath}$scriptLog
+
+## If desired, here's a one-line variable of the log
+## theLogg="/Users/bob.zavala/rsyncLogs/rsync-${theDate}-${theStartTime}.log"
+
+echo "rsync Script start time: ${theStartTime}\n " > ${logPath}$scriptLog
+echo "rsync Script start time: ${theStartTime}\n "
+echo "** " >> ${logPath}$scriptLog
+echo "** "
+echo "Hello ${USER}! Welcome to the my_rsync script!" >> ${logPath}$scriptLog
+echo "Hello ${USER}! Welcome to the my_rsync script!"
 echo "This script is running on machine ${HOST}." >> ${logPath}$scriptLog
+echo "This script is running on machine ${HOST}."
 echo "**\n " >> ${logPath}$scriptLog
- 
-rsync -av -i --rsh=ssh /Users/bob.zavala/Desktop/bobMacBackUp medea:/mnt/nofs/projects/rsync >> ${logPath}$scriptLog  
+echo "**\n " 
+
+## The format of the command on the next line, using re-direction, hides the output of rsync from the user.
+## All output is placed into the log file. 
+## rsync -av -i --rsh=ssh --progress /Users/bob.zavala/Desktop/bobMacBackUp medea:/mnt/nofs/projects/rsync >> ${logPath}$scriptLog  
+
+## By using the option to name the log file the progress in placed in the log file and the output of
+## the progress is NOT re-directed and is visible to the user. This visible progress display is more
+## user friendly.
+rsync -av -i --rsh=ssh --progress --log-file=${logPath}$scriptLog /Users/bob.zavala/Desktop/bobMacBackUp medea:/mnt/nofs/projects/rsync 
 
 ## Ending time stuff, close out log
 theEndTime=`date +%T`
 echo " " >> ${logPath}$scriptLog
 echo "*** " >> ${logPath}$scriptLog
-echo "rsync Script end time:${theStartTime}" >> ${logPath}$scriptLog
+echo "rsync Script end time :${theStartTime}" >> ${logPath}$scriptLog
 echo "****\n " >> ${logPath}$scriptLog
 
 # Inform the user the script ended


### PR DESCRIPTION
Changed the rsync command in the script to eliminate re-direction. The logfile is set using the option --log-file= and progress of the rsync command is reported to the user via the option --progress. Tested and found to work on a MacBook with Sonoma 14.6.1 and the --log-file format by default is an ASCII text file.